### PR TITLE
added more information the 2017 Corolla PSCM document

### DIFF
--- a/EPS/89650-02B50/README.md
+++ b/EPS/89650-02B50/README.md
@@ -30,10 +30,15 @@
 
 ### Initialization
 The following CAN messages are required to initialize the EPS so it can be controlled.
-| ID (hex) | LENGTH (bytes) | NOTES |
-|----------|----------------|-------|
-| 0xaa | 8 | WHEEL_SPEEDS |
-| 0x25 | 8 | STEER_ANGLE_SENSOR |
+| ID (hex) | LENGTH (bytes) | Frequency (Hz) | NOTES |
+|----------|----------------|----------------|-------|
+| 0xaa | 8 | 40-84 | WHEEL_SPEEDS |
+| 0x25 | 8 | 40-84 | STEER_ANGLE_SENSOR |
+| 0xb4 | 8 | 40-84 | SPEED |
+| 0x1c4 | 8 | 40-84 | [0x05, 0xea, 0x1b, 0x08, 0x00, 0x00, 0xc0, 0x9f] |
+| 0x4xb | 8 | 40-84 | [0x66, 0x06, 0x08, 0x0a, 0x02, 0x00, 0x00, 0x00] |
+
+*Note: If the above message specifies an array of bytes, it hasn't been identified. However, all you have to do is send those exact bytes at the provided frequency.*
 
 DBC Samples:
 ```
@@ -47,6 +52,11 @@ BO_ 170 WHEEL_SPEEDS: 8 XXX
  SG_ WHEEL_SPEED_FL : 23|16@0+ (0.01,-67.67) [0|250] "km/h" XXX
  SG_ WHEEL_SPEED_RR : 39|16@0+ (0.01,-67.67) [0|250] "km/h" XXX
  SG_ WHEEL_SPEED_RL : 55|16@0+ (0.01,-67.67) [0|250] "km/h" XXX
+
+BO_ 180 SPEED: 8 XXX
+ SG_ ENCODER : 39|8@0+ (1,0) [0|255] "" XXX
+ SG_ SPEED : 47|16@0+ (0.01,0) [0|250] "km/h" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 ```
 
 
@@ -69,3 +79,18 @@ BO_ 740 STEERING_LKA: 5 XXX
  SG_ STEER_TORQUE_CMD : 15|16@0- (1,0) [0|65535] "" XXX
  SG_ CHECKSUM : 39|8@0+ (1,0) [0|255] "" XXX
  ```
+
+### Error States
+In the EPS_STATUS message, the LKA_STATE is usefull for debugging. 
+- State 1 - Good state, ready to listen for STEERING_LKA messages
+- State 3 - Good (enough) state (it is missing the CAN messages that the camera sends, but they aren't required for controls to work), ready to listen for STEERING_LKA messages
+- State 5 - LKA is active and in a good state
+- State 9 - Temporary Fault (lasts 2 seconds)
+- State 17 - Steering Rate is too high
+- State 21 - Temporary fault triggered
+- State 25 - Temporary fault triggered
+
+If a fault is triggered, it will flip to that specific state for 1 frame, and then flip to state 9 for the duration of the lockout.
+
+The ECU checks the parts of the STEER_ANGLE_SENSOR message to ensure that any STEERING_LKA messages are safe to apply. For example, if the STEER_RATE field is too high, the ECU will go into a fault state and not respond to STEERING_LKA messages for 2 seconds.
+


### PR DESCRIPTION
- added more messages that are required to get the PSCM to enable without error
- added some documentation on various error states

I personally send my spoofed messages at around 80 Hz, this seems high and probably not required, that is why I specified a range.